### PR TITLE
Make `userStrings` in command schema an array

### DIFF
--- a/src/chat/commandSchema/commandSchema.ts
+++ b/src/chat/commandSchema/commandSchema.ts
@@ -83,7 +83,7 @@ export type ExtensionCommandParameterSchema = {
          * - "The programming language for your function project."
          */
         description: string;
-    }
+    }[]
     copilotStrings: {
         /**
          * A descriptive blurb to give to copilot that describes the purpose of the parameter within the scope of the


### PR DESCRIPTION
If I understand things correctly, this was meant to be an array.

https://github.com/microsoft/vscode-azure-agent/issues/2