### PR TITLE
Implement basic resource augmented generation (RAG) for learn and brainstorm

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -15,6 +15,13 @@ async function prepareForWebpack(): Promise<void> {
         .replace('out/src/extension', 'dist/extension.bundle')
         .replace(', true /* ignoreBundle */', '');
     await fse.writeFile(mainJsPath, contents);
+
+    // TODO: Figure out how to get this working, webpack npm script is failing right now
+    // const packageJsonPath = path.join(__dirname, 'package.json');
+    // const packageJsonObj = require(packageJsonPath);
+    // packageJsonObj.openAiConfigEndpoint = process.env.OPENAI_CONFIG_ENDPOINT?.toString();
+    // packageJsonObj.extensionIdentity = process.env.VSCODE_AZURE_AGENT_IDENTITY?.toString();
+    // await fse.writeFile(packageJsonPath, JSON.stringify(packageJsonObj, undefined, 4));
 }
 
 async function cleanReadme() {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
         "readonlyMessage"
     ],
     "main": "./main.js",
-    "contributes": {
-    },
+    "contributes": {},
     "scripts": {
         "vscode:prepublish": "npm run webpack-prod",
         "build": "tsc",
@@ -75,7 +74,10 @@
         "webpack-cli": "^4.6.0"
     },
     "dependencies": {
-        "@microsoft/vscode-azext-utils": "^2.1.0",
+        "@azure/identity": "^4.0.0",
+        "@azure/openai": "^1.0.0-beta.8",
+        "@microsoft/vscode-azext-azureutils": "^2.0.2",
+        "@microsoft/vscode-azext-utils": "^2.1.4",
         "vscode-nls": "^4.1.1"
     },
     "extensionDependencies": [

--- a/src/chat/rag.ts
+++ b/src/chat/rag.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createHttpHeaders } from "@azure/core-rest-pipeline";
+import { ClientSecretCredential } from "@azure/identity";
+import { AzureKeyCredential, OpenAIClient } from "@azure/openai";
+import { AzExtRequestPrepareOptions, sendRequestWithTimeout } from "@microsoft/vscode-azext-azureutils";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../extensionVariables";
+
+const microsoftLearnEndpoint = "https://learn.microsoft.com/api/knowledge/vector/document/relevantItems";
+const microsoftLearnScopes = ["api://5405974b-a0ac-4de0-80e0-9efe337ea291/.default"];
+
+type OpenAiConfig = {
+    version: "1.0";
+    endpoint: string;
+    embeddingModel: {
+        name: string;
+        version: string;
+    };
+    key: string;
+    deploymentName: string;
+};
+
+type ExtensionIdentity = {
+    clientId: string;
+    secret: string;
+    tenant: string;
+};
+
+export type MicrosoftLearnKnowledgeServiceQueryResponse = {
+    count: number;
+    items: MicrosoftLearnKnowledgeServiceDocument[];
+};
+
+export type MicrosoftLearnKnowledgeServiceDocument = {
+    content: string;
+    contentUrl: string;
+    depotName: string;
+    id: string;
+    lastModifiedDateTime: string;
+    pageType: string;
+    score: number;
+    title: string;
+};
+
+export async function getMicrosoftLearnRagContent(context: IActionContext, input: string): Promise<MicrosoftLearnKnowledgeServiceDocument | undefined> {
+    const openAiConfig = await getOpenAiConfig(context);
+    if (!openAiConfig) {
+        return undefined;
+    }
+
+    // Adding "Azure" to the input string to generall bias the search toward Azure docs. We can probably do better though.
+    const inputEmbedding = await createAda002Embedding(openAiConfig, "Azure " + input);
+    if (!inputEmbedding) {
+        return undefined;
+    }
+
+    const learnKnowledgeServiceResponse = await queryMicrosoftLearnKnowledgeService(context, inputEmbedding);
+    return learnKnowledgeServiceResponse.at(0);
+}
+
+async function queryMicrosoftLearnKnowledgeService(context: IActionContext, inputEmbedding: number[]): Promise<MicrosoftLearnKnowledgeServiceDocument[]> {
+    try {
+        const extensionIdentity = getExtensionIdentity();
+        if (!extensionIdentity) {
+            return [];
+        }
+
+        const credential = new ClientSecretCredential(extensionIdentity.tenant, extensionIdentity.clientId, extensionIdentity.secret);
+        const bearerToken = await credential.getToken(microsoftLearnScopes);
+        const requestTimeout = 2 * 1000;
+        const requestHeaders = createHttpHeaders({ "Authorization": `Bearer ${bearerToken.token}`, "Content-Type": "application/json" });
+        const requestBody = JSON.stringify({ "vector": { "values": inputEmbedding }, "top": 1 });
+        const requestOptions: AzExtRequestPrepareOptions = { method: "POST", url: microsoftLearnEndpoint, headers: requestHeaders, body: requestBody };
+        const response = await sendRequestWithTimeout(context, requestOptions, requestTimeout, undefined);
+        const responseBody = response.parsedBody as MicrosoftLearnKnowledgeServiceQueryResponse;
+        return responseBody.items;
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
+}
+
+async function createAda002Embedding(config: OpenAiConfig, input: string): Promise<number[] | undefined> {
+    try {
+        const client = await getOpenAiClient(config);
+        const getEmbeddingsResponse = await client.getEmbeddings(config.deploymentName, [input]);
+        const embedding = getEmbeddingsResponse.data.at(0)?.embedding;
+        return embedding;
+    } catch (error) {
+        console.error(error);
+        return undefined;
+    }
+}
+
+async function getOpenAiClient(config: OpenAiConfig): Promise<OpenAIClient> {
+    return new OpenAIClient(config.endpoint, new AzureKeyCredential(config.key));
+}
+
+async function getOpenAiConfig(context: IActionContext): Promise<OpenAiConfig | undefined> {
+    const openAiConfigEndpoint: string | undefined = getOpenAiConfigEndpoint();
+    if (!openAiConfigEndpoint) {
+        return undefined;
+    }
+
+    try {
+        const requestTimeout = 2 * 1000;
+        const requestOptions: AzExtRequestPrepareOptions = { method: "GET", url: openAiConfigEndpoint };
+        const response = await sendRequestWithTimeout(context, requestOptions, requestTimeout, undefined);
+        return response.parsedBody as OpenAiConfig | undefined;
+    } catch (error) {
+        console.error(error);
+        return undefined;
+    }
+}
+
+function getOpenAiConfigEndpoint(): string | undefined {
+    return ext.context.extension.packageJSON.openAiConfigEndpoint || process.env.OPENAI_CONFIG_ENDPOINT || undefined;
+}
+
+function getExtensionIdentity(): ExtensionIdentity | undefined {
+    const envVar = process.env.VSCODE_AZURE_AGENT_IDENTITY;
+    if (!!ext.context.extension.packageJSON.extensionIdentity) {
+        return ext.context.extension.packageJSON.extensionIdentity;
+    } else if (!!envVar) {
+        return JSON.parse(envVar);
+    } else {
+        return undefined;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,8 @@
 
 'use strict';
 
-import { IActionContext, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
+import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
+import { IActionContext, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { registerChatAgent } from './chat/agent';
 import { ext } from './extensionVariables';
@@ -13,6 +14,10 @@ import { ext } from './extensionVariables';
 export async function activateInternal(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<void> {
     ext.context = context;
     ext.ignoreBundle = ignoreBundle;
+    ext.outputChannel = createAzExtOutputChannel('Azure Agent', ext.prefix);
+
+    registerUIExtensionVariables(ext);
+    registerAzureUtilsExtensionVariables(ext);
 
     await callWithTelemetryAndErrorHandling(`${ext.prefix}.activate`, async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,13 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IAzExtOutputChannel } from "@microsoft/vscode-azext-utils";
 import { ExtensionContext } from "vscode";
-
 /**
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
  */
 export namespace ext {
     export let context: ExtensionContext;
     export let ignoreBundle: boolean | undefined;
-    export const prefix: string = 'azextAgent';
+    export let outputChannel: IAzExtOutputChannel;
+    export const prefix: string = "azextAgent";
 }


### PR DESCRIPTION
This change adds basic resource augmented generation (RAG) for learn and brainstorm commands. By using RAG, we ground GH Copilot with up-to-date information from Microsoft Learn (aka Microsoft docs). This is done by:

1. Getting a query from the user
2. Sending it to an Azure Open AI resource (that we own) which turns the query into vector embeddings
3. Sending the vector embeddings to the Microsoft Learn Knowledge Service

To do step 2, we make use of a remote configuration which defines how to connect to our Azure Open AI resource. This includes the endpoint for the resource, an API key, and details about the model deployment used to generate the embeddings.

To do step 3, we have to acquire a token on behalf of the extension (not the user). Therefore, I have created an identity in the Microsoft tenant for the extension. This identity is used to acquire a token for calling the Microsoft Learn Knowledge Service.

For production .vsix's, the intention is that the:
- URL of the remote configuration
- Extension's identity

Are written to the package.json and then read at runtime.