### PR TITLE
Add agent level help command

### DIFF
--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -1,12 +1,14 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
 import * as vscode from "vscode";
 import { ext } from '../extensionVariables';
 import { agentDescription, agentFullName, agentName, maxFollowUps } from "./agentConsts";
+import { agentHelpCommandName, getAgentHelpCommand } from "./agentHelpSlashCommand";
 import { AgentBenchmarker } from "./benchmarking/benchmarking";
 import { verbatimCopilotInteraction } from "./copilotInteractions";
 import { appServiceExtensionSlashCommandsOwner, functionsExtensionSlashCommandsOwner, storageExtensionSlashCommandsOwner } from "./extensionSlashCommands";
@@ -31,14 +33,13 @@ export interface IAgentRequestHandler {
 /**
  * Owns slash commands that are knowingly exposed to the user.
  */
-const agentSlashCommandsOwner = new SlashCommandsOwner(
-    new Map([
-        functionsExtensionSlashCommandsOwner.getTopLevelSlashCommand(),
-        storageExtensionSlashCommandsOwner.getTopLevelSlashCommand(),
-        appServiceExtensionSlashCommandsOwner.getTopLevelSlashCommand(),
-    ]),
-    { noInput: noInputHandler, default: defaultHandler, }
-);
+const agentSlashCommandsOwner = new SlashCommandsOwner({ noInput: agentHelpCommandName, default: defaultHandler, });
+agentSlashCommandsOwner.addInvokeableSlashCommands(new Map([
+    functionsExtensionSlashCommandsOwner.getTopLevelSlashCommand(),
+    storageExtensionSlashCommandsOwner.getTopLevelSlashCommand(),
+    appServiceExtensionSlashCommandsOwner.getTopLevelSlashCommand(),
+    getAgentHelpCommand(agentSlashCommandsOwner),
+]));
 
 /**
  * Owns slash commands that are hidden from the user and related to benchmarking the agent.
@@ -49,10 +50,10 @@ const agentBenchmarker = new AgentBenchmarker(agentSlashCommandsOwner);
  * Owns slash commands that are hidden from the user.
  */
 const agentHiddenSlashCommandsOwner = new SlashCommandsOwner(
-    new Map([toggleRagSlashCommand, getRagStatusSlashCommand]),
     { noInput: undefined, default: undefined },
     { disableIntentDetection: true }
 );
+agentHiddenSlashCommandsOwner.addInvokeableSlashCommands(new Map([toggleRagSlashCommand, getRagStatusSlashCommand]));
 
 export function registerChatAgent() {
     try {
@@ -105,7 +106,7 @@ function getSubCommands(_token: vscode.CancellationToken): vscode.ProviderResult
 }
 
 async function defaultHandler(request: AgentRequest): Promise<SlashCommandHandlerResult> {
-    const defaultSystemPrompt1 = `You are an expert in using the Azure Extensions for VS Code. The user needs your help with something related to either Azure, VS Code, and/or the Azure Extensions for VS Code. Do your best to answer their question. The user is currently using VS Code and has one or more Azure Extensions for VS Code installed. Do not overwhelm the user with too much information. Keep responses short and sweet.`;
+    const defaultSystemPrompt1 = `You are an expert in using the all things Azure. The user needs your help with something related to either Azure and/or the Azure Extensions for VS Code. Do your best to answer their question. The user is currently using VS Code and has one or more Azure Extensions for VS Code installed. Do not overwhelm the user with too much information. Keep responses short and sweet.`;
 
     const { copilotResponded } = await verbatimCopilotInteraction(defaultSystemPrompt1, request);
     if (!copilotResponded) {
@@ -114,10 +115,4 @@ async function defaultHandler(request: AgentRequest): Promise<SlashCommandHandle
     } else {
         return { chatAgentResult: {}, followUp: [], };
     }
-}
-
-async function noInputHandler(request: AgentRequest): Promise<SlashCommandHandlerResult> {
-    const slashCommandsMarkdown = agentSlashCommandsOwner.getSlashCommands().map(([name, config]) => `- \`/${name}\` - ${config.longDescription || config.shortDescription}`).join("\n");
-    request.progress.report({ content: `Hi! I can help you with learn about, and develop code for Azure. If you know what you'd like to do, you can use the following commands to ask me for help:\n\n${slashCommandsMarkdown}\n\nOtherwise feel free to ask or tell me anything and I'll do my best to help.` });
-    return { chatAgentResult: {}, followUp: [] };
 }

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -106,7 +106,7 @@ function getSubCommands(_token: vscode.CancellationToken): vscode.ProviderResult
 }
 
 async function defaultHandler(request: AgentRequest): Promise<SlashCommandHandlerResult> {
-    const defaultSystemPrompt1 = `You are an expert in using the all things Azure. The user needs your help with something related to either Azure and/or the Azure Extensions for VS Code. Do your best to answer their question. The user is currently using VS Code and has one or more Azure Extensions for VS Code installed. Do not overwhelm the user with too much information. Keep responses short and sweet.`;
+    const defaultSystemPrompt1 = `You are an expert in all things Azure. The user needs your help with something related to either Azure and/or the Azure Extensions for VS Code. Do your best to answer their question. The user is currently using VS Code and has one or more Azure Extensions for VS Code installed. Do not overwhelm the user with too much information. Keep responses short and sweet.`;
 
     const { copilotResponded } = await verbatimCopilotInteraction(defaultSystemPrompt1, request);
     if (!copilotResponded) {

--- a/src/chat/agentHelpSlashCommand.ts
+++ b/src/chat/agentHelpSlashCommand.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AgentRequest } from "./agent";
+import { type AgentRequest } from "./agent";
 import { agentName } from "./agentConsts";
-import { SlashCommand, SlashCommandHandlerResult, SlashCommandsOwner } from "./slashCommands";
+import { type SlashCommand, type SlashCommandHandlerResult, type SlashCommandsOwner } from "./slashCommands";
 
 export const agentHelpCommandName = "help";
 
@@ -21,6 +21,6 @@ export function getAgentHelpCommand(agentSlashCommandsOwner: SlashCommandsOwner)
 
 async function agentHelpHandler(agentSlashCommandsOwner: SlashCommandsOwner, request: AgentRequest): Promise<SlashCommandHandlerResult> {
     const slashCommandsMarkdown = agentSlashCommandsOwner.getSlashCommands().map(([name, config]) => `- \`/${name}\` - ${config.longDescription || config.shortDescription}`).join("\n");
-    request.progress.report({ content: `Hi! I can help you with learn about, and develop code for Azure. Feel free to ask or tell me anything and I'll do my best to help. Or, if you know what you'd like to do, you can use the following commands to ask me for help:\n\n${slashCommandsMarkdown}` });
+    request.progress.report({ content: `Hi! I can help you learn about and develop code for Azure. Feel free to ask or tell me anything and I'll do my best to help. Or, if you know what you'd like to do, you can use the following commands:\n\n${slashCommandsMarkdown}` });
     return { chatAgentResult: {}, followUp: [] };
 }

--- a/src/chat/agentHelpSlashCommand.ts
+++ b/src/chat/agentHelpSlashCommand.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AgentRequest } from "./agent";
+import { agentName } from "./agentConsts";
+import { SlashCommand, SlashCommandHandlerResult, SlashCommandsOwner } from "./slashCommands";
+
+export const agentHelpCommandName = "help";
+
+export function getAgentHelpCommand(agentSlashCommandsOwner: SlashCommandsOwner): SlashCommand {
+    return [agentHelpCommandName,
+        {
+            shortDescription: `Get help with using the @${agentName} agent.`,
+            longDescription: `Get help with using the @${agentName} agent.`,
+            intentDescription: `This is best when users want to know what you can do for them, how you can help them, or how to best use you as an agent. You may be referred to as "you", "this", "bot" or other similar langauge. This is not the best if the user asks about or mentions a particular Azure service, topic, feature, or question.`,
+            handler: (request) => agentHelpHandler(agentSlashCommandsOwner, request)
+        }];
+}
+
+async function agentHelpHandler(agentSlashCommandsOwner: SlashCommandsOwner, request: AgentRequest): Promise<SlashCommandHandlerResult> {
+    const slashCommandsMarkdown = agentSlashCommandsOwner.getSlashCommands().map(([name, config]) => `- \`/${name}\` - ${config.longDescription || config.shortDescription}`).join("\n");
+    request.progress.report({ content: `Hi! I can help you with learn about, and develop code for Azure. Feel free to ask or tell me anything and I'll do my best to help. Or, if you know what you'd like to do, you can use the following commands to ask me for help:\n\n${slashCommandsMarkdown}` });
+    return { chatAgentResult: {}, followUp: [] };
+}

--- a/src/chat/benchmarking/benchmarking.ts
+++ b/src/chat/benchmarking/benchmarking.ts
@@ -67,7 +67,9 @@ export class AgentBenchmarker implements IAgentRequestHandler {
 
         const slashCommands = new Map([this._getBenchmarkSlashCommand(), this._getBenchmarkStatsSlashCommand()]);
         const fallbackSlashCommandHandlers: FallbackSlashCommandHandlers = { noInput: undefined, default: undefined };
-        this._benchmarkerSlashCommandsOwner = new SlashCommandsOwner(slashCommands, fallbackSlashCommandHandlers, { disableIntentDetection: true });
+
+        this._benchmarkerSlashCommandsOwner = new SlashCommandsOwner(fallbackSlashCommandHandlers, { disableIntentDetection: true });
+        this._benchmarkerSlashCommandsOwner.addInvokeableSlashCommands(slashCommands);
 
         this._continuationIndex = 0;
     }

--- a/src/chat/extensionSlashCommands.ts
+++ b/src/chat/extensionSlashCommands.ts
@@ -5,7 +5,7 @@
 
 import { type AgentRequest } from "./agent";
 import { getBrainstormCommand, getLearnCommand, getMightBeInterestedHandler, type BrainstormCommandConfig, type LearnCommandConfig, type MightBeInterestedHandlerConfig } from "./commonCommandsAndHandlers";
-import { SlashCommandsOwner, type InvokeableSlashCommands, type SlashCommand, type SlashCommandHandlerResult } from "./slashCommands";
+import { SlashCommandsOwner, type SlashCommand, type SlashCommandHandlerResult, type SlashCommands } from "./slashCommands";
 import { slashCommandFromWizardBasedExtensionCommand } from "./wizardBasedExtensionSchema/slashCommandFromWizardBaseExtensionCommand";
 import { type WizardBasedExtension } from "./wizardBasedExtensionSchema/wizardBasedExtensionSchema";
 import { getNoCommandsWizardExtensionConfig } from "./wizardBasedExtensionSchema/wizardExtensions";
@@ -41,7 +41,7 @@ export class ExtensionSlashCommandsOwner {
             this._commandName,
             {
                 shortDescription: `Work with the ${this._extensionName} extension for VS Code and/or ${this._azureServiceName}`,
-                longDescription: `Use this command when you want to work with the ${this._extensionName} extension for VS Code and ${this._azureServiceName}.`,
+                longDescription: `Use the command when you want to learn about or work with ${this._azureServiceName} or the ${this._extensionName} extension for VS Code.`,
                 intentDescription: `This is best when a user prompt could be related to the ${this._extensionName} extension for VS Code or ${this._azureServiceName}.`,
                 handler: (...args) => this._handleExtensionSlashCommand(...args),
             }
@@ -55,7 +55,7 @@ export class ExtensionSlashCommandsOwner {
 
     private async _getExtensionSlashCommandsOwner(): Promise<SlashCommandsOwner> {
         if (!this._extensionSlashCommandsOwner) {
-            const extensionSlashCommands: InvokeableSlashCommands = new Map([
+            const extensionSlashCommands: SlashCommands = new Map([
                 getBrainstormCommand(this._commonSlashCommandConfigs.brainstorm),
                 getLearnCommand(this._commonSlashCommandConfigs.learn),
             ]);
@@ -68,7 +68,8 @@ export class ExtensionSlashCommandsOwner {
                 extensionSlashCommands.set(slashCommand[0], slashCommand[1]);
             }
             const mightBeInterestedHandler = getMightBeInterestedHandler(this._commonSlashCommandConfigs.mightBeInterested);
-            this._extensionSlashCommandsOwner = new SlashCommandsOwner(extensionSlashCommands, { noInput: mightBeInterestedHandler, default: mightBeInterestedHandler });
+            this._extensionSlashCommandsOwner = new SlashCommandsOwner({ noInput: mightBeInterestedHandler, default: mightBeInterestedHandler });
+            this._extensionSlashCommandsOwner.addInvokeableSlashCommands(extensionSlashCommands);
         }
         return this._extensionSlashCommandsOwner;
     }


### PR DESCRIPTION
Can now surface a `/help` command, both via auto-complete and first round intent detection. Should be able to do the same thing (via second round intent detection) for service extensions once those are more fleshed out.