### PR TITLE
Improve the user experience when an extension is not installed

### DIFF
--- a/src/chat/commonCommandsAndHandlers.ts
+++ b/src/chat/commonCommandsAndHandlers.ts
@@ -17,7 +17,7 @@ export type BrainstormCommandConfig = {
     shortTopic: string;
     longTopic: string;
     noInputSuggestions: string[];
-    followUpApiProvider?: WizardBasedExtension;
+    associatedExtension?: WizardBasedExtension;
 }
 
 export function getBrainstormCommand(config: BrainstormCommandConfig): SlashCommand {
@@ -45,10 +45,15 @@ function brainstormHandler(config: BrainstormCommandConfig, request: AgentReques
                 if (ragContent !== undefined) {
                     request.progress.report({ reference: vscode.Uri.parse(ragContent.contentUrl) });
                 }
-                const followUps = [
-                    ...(config.followUpApiProvider !== undefined ? await generateExtensionCommandFollowUps(copilotResponse, config.followUpApiProvider, request) : []),
-                    ...(await generateNextQuestionsFollowUps(copilotResponse, request))
-                ];
+                const followUps: vscode.ChatAgentFollowup[] = [];
+                if (config.associatedExtension !== undefined && config.associatedExtension.isInstalled()) {
+                    followUps.push(...(await generateExtensionCommandFollowUps(copilotResponse, config.associatedExtension, request)));
+                } else if (config.associatedExtension !== undefined && !config.associatedExtension.isInstalled()) {
+                    request.progress.report({ content: `\n\nFor additional help related to ${config.longTopic}, install the ${config.associatedExtension.displayName} extension for VS Code.` });
+                    followUps.push({ commandId: "workbench.extensions.search", args: [config.associatedExtension.extensionId], title: `Install ${config.associatedExtension.displayName}` });
+                }
+                followUps.push(...(await generateNextQuestionsFollowUps(copilotResponse, request)));
+
                 return { chatAgentResult: {}, followUp: followUps, };
             }
         }
@@ -65,7 +70,7 @@ export type LearnCommandConfig = {
     shortTopic: string;
     longTopic: string;
     noInputSuggestions: string[];
-    followUpApiProvider?: WizardBasedExtension;
+    associatedExtension?: WizardBasedExtension;
 }
 
 export function getLearnCommand(config: LearnCommandConfig): SlashCommand {
@@ -93,10 +98,15 @@ function learnHandler(config: LearnCommandConfig, request: AgentRequest): Promis
                 if (ragContent !== undefined) {
                     request.progress.report({ reference: vscode.Uri.parse(ragContent.contentUrl) });
                 }
-                const followUps = [
-                    ...(config.followUpApiProvider !== undefined ? await generateExtensionCommandFollowUps(copilotResponse, config.followUpApiProvider, request) : []),
-                    ...(await generateNextQuestionsFollowUps(copilotResponse, request))
-                ];
+                const followUps: vscode.ChatAgentFollowup[] = [];
+                if (config.associatedExtension !== undefined && config.associatedExtension.isInstalled()) {
+                    followUps.push(...(await generateExtensionCommandFollowUps(copilotResponse, config.associatedExtension, request)));
+                } else if (config.associatedExtension !== undefined && !config.associatedExtension.isInstalled()) {
+                    request.progress.report({ content: `\n\nFor additional help related to ${config.longTopic}, install the ${config.associatedExtension.displayName} extension for VS Code.` });
+                    followUps.push({ commandId: "workbench.extensions.search", args: [config.associatedExtension.extensionId], title: `Install the ${config.associatedExtension.displayName} Extension` });
+                }
+                followUps.push(...(await generateNextQuestionsFollowUps(copilotResponse, request)));
+
                 return { chatAgentResult: {}, followUp: followUps, };
             }
         }

--- a/src/chat/extensionSlashCommands.ts
+++ b/src/chat/extensionSlashCommands.ts
@@ -49,18 +49,18 @@ export class ExtensionSlashCommandsOwner {
     }
 
     private async _handleExtensionSlashCommand(request: AgentRequest): Promise<SlashCommandHandlerResult> {
-        const extensionLevelSlashCommandsOwner = await this._getExtensionSlashCommandsOwner();
+        const extensionLevelSlashCommandsOwner = await this._getExtensionSlashCommandsOwner(request);
         return await extensionLevelSlashCommandsOwner.handleRequestOrPrompt(request);
     }
 
-    private async _getExtensionSlashCommandsOwner(): Promise<SlashCommandsOwner> {
+    private async _getExtensionSlashCommandsOwner(request: AgentRequest): Promise<SlashCommandsOwner> {
         if (!this._extensionSlashCommandsOwner) {
+            await this._extension.activate(request);
+
             const extensionSlashCommands: SlashCommands = new Map([
                 getBrainstormCommand(this._commonSlashCommandConfigs.brainstorm),
                 getLearnCommand(this._commonSlashCommandConfigs.learn),
             ]);
-
-            await this._extension.activate();
 
             const extensionWizardCommands = await this._extension.getWizardCommands();
             for (const commandSchema of extensionWizardCommands) {
@@ -75,7 +75,7 @@ export class ExtensionSlashCommandsOwner {
     }
 }
 
-const functionsExtension = getNoCommandsWizardExtensionConfig("Azure Functions");
+const functionsExtension = getNoCommandsWizardExtensionConfig("Azure Functions", "ms-azuretools.vscode-azurefunctions");
 const functionsCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs = {
     brainstorm: {
         shortTopic: "Azure Functions",
@@ -85,7 +85,7 @@ const functionsCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs = 
             "How can I use Azure Functions to run background jobs or scheduled tasks?",
             "How can I use Azure Functions to process files as soon as they are uploaded?",
         ],
-        followUpApiProvider: functionsExtension,
+        associatedExtension: functionsExtension,
     },
     learn: {
         shortTopic: "Azure Functions",
@@ -95,7 +95,7 @@ const functionsCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs = 
             "How scalable is Azure functions?",
             "Is Azure functions serverless?",
         ],
-        followUpApiProvider: functionsExtension,
+        associatedExtension: functionsExtension,
     },
     mightBeInterested: {
         topic: "Azure Functions extension for VS Code",
@@ -114,7 +114,7 @@ export const functionsExtensionSlashCommandsOwner: ExtensionSlashCommandsOwner =
     functionsCommonSlashCommandConfigs
 );
 
-const storageExtension = getNoCommandsWizardExtensionConfig("Azure Storage");
+const storageExtension = getNoCommandsWizardExtensionConfig("Azure Storage", "ms-azuretools.vscode-azurestorage");
 const storageCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs = {
     brainstorm: {
         shortTopic: "Azure Storage",
@@ -123,7 +123,8 @@ const storageCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs = {
             "How can I use Azure Storage to store files?",
             "How can I use Azure Storage to communicate tasks between services?",
             "How can I use Azure Storage to store tabular data?",
-        ]
+        ],
+        associatedExtension: storageExtension,
     },
     learn: {
         shortTopic: "Azure Storage",
@@ -132,7 +133,8 @@ const storageCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs = {
             "What is the difference between Azure Storage and Azure CosmosDB?",
             "How scalable is Azure Storage?",
             "What developer tooling exists for Azure Storage?",
-        ]
+        ],
+        associatedExtension: storageExtension,
     },
     mightBeInterested: {
         topic: "Azure Storage extension for VS Code",
@@ -151,7 +153,7 @@ export const storageExtensionSlashCommandsOwner: ExtensionSlashCommandsOwner = n
     storageCommonSlashCommandConfigs
 );
 
-const appServiceExtension = getNoCommandsWizardExtensionConfig("Azure App Service");
+const appServiceExtension = getNoCommandsWizardExtensionConfig("Azure App Service", "ms-azuretools.vscode-azureappservice");
 const appServiceCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs = {
     brainstorm: {
         shortTopic: "Azure App Service",
@@ -160,7 +162,8 @@ const appServiceCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs =
             "How can I use Azure App Service to host a website?",
             "How can I use Azure App Service to host an API?",
             "How can I use Azure App Service to host a web app?",
-        ]
+        ],
+        associatedExtension: appServiceExtension,
     },
     learn: {
         shortTopic: "Azure App Service",
@@ -169,7 +172,8 @@ const appServiceCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs =
             "What is the difference between Azure App Service and Azure Functions?",
             "How scalable is Azure App Service?",
             "What programming languages can I use to create an Azure App Service?",
-        ]
+        ],
+        associatedExtension: appServiceExtension,
     },
     mightBeInterested: {
         topic: "Azure App Service extension for VS Code",

--- a/src/chat/extensionSlashCommands.ts
+++ b/src/chat/extensionSlashCommands.ts
@@ -98,12 +98,13 @@ const functionsCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs = 
         associatedExtension: functionsExtension,
     },
     mightBeInterested: {
-        topic: "Azure Functions extension for VS Code",
+        topic: "Azure Functions and/or the Azure Functions extension for VS Code",
         suggestions: [
             "I want to use Azure Functions to serve dynamic content and APIs.",
             "I want to use Azure Functions to run background jobs or scheduled tasks.",
             "I want to use Azure Functions to process files as soon as they are uploaded.",
-        ]
+        ],
+        associatedExtension: functionsExtension,
     }
 }
 export const functionsExtensionSlashCommandsOwner: ExtensionSlashCommandsOwner = new ExtensionSlashCommandsOwner(
@@ -137,12 +138,13 @@ const storageCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs = {
         associatedExtension: storageExtension,
     },
     mightBeInterested: {
-        topic: "Azure Storage extension for VS Code",
+        topic: "Azure Storage and/or the Azure Storage extension for VS Code",
         suggestions: [
             "I want to use Azure Storage to to store files.",
             "I want to use Azure Storage to communicate tasks between services.",
             "I want to use Azure Storage to store tabular data.",
-        ]
+        ],
+        associatedExtension: storageExtension,
     }
 }
 export const storageExtensionSlashCommandsOwner: ExtensionSlashCommandsOwner = new ExtensionSlashCommandsOwner(
@@ -176,12 +178,13 @@ const appServiceCommonSlashCommandConfigs: CommonSlashCommandAndHandlerConfigs =
         associatedExtension: appServiceExtension,
     },
     mightBeInterested: {
-        topic: "Azure App Service extension for VS Code",
+        topic: "Azure App Service and/or the Azure App Service extension for VS Code",
         suggestions: [
             "I want to use Azure App Service to host a website.",
             "I want to use Azure App Service to host an API.",
             "I want to use Azure App Service to host a web app.",
-        ]
+        ],
+        associatedExtension: appServiceExtension,
     }
 };
 export const appServiceExtensionSlashCommandsOwner: ExtensionSlashCommandsOwner = new ExtensionSlashCommandsOwner(

--- a/src/chat/wizardBasedExtensionSchema/wizardBasedExtensionSchema.ts
+++ b/src/chat/wizardBasedExtensionSchema/wizardBasedExtensionSchema.ts
@@ -7,6 +7,7 @@
 import { type IAzureUserInput } from "@microsoft/vscode-azext-utils";
 import * as vscode from "vscode";
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+import { AgentRequest } from "../agent";
 import { type AzureUserInputQueue, type IAgentUserInput } from "./AgentUserInput";
 
 export type WizardBasedExtensionCommandConfig = {
@@ -98,20 +99,35 @@ export type WizardBasedExtensionConfig = {
 }
 
 export class WizardBasedExtension {
+    public readonly extensionId: string;
     public readonly displayName: string;
     public readonly runWizardCommandWithInputsCommandId: string;
 
-    private _config: WizardBasedExtensionConfig;
+    private readonly _config: WizardBasedExtensionConfig;
+    private _extension: vscode.Extension<any> | undefined;
 
     constructor(config: WizardBasedExtensionConfig) {
+        this.extensionId = config.extensionId;
         this.displayName = config.displayName;
         this.runWizardCommandWithInputsCommandId = config.runWizardCommandWithInputsCommandId;
         this._config = config;
     }
 
-    public async activate(): Promise<void> {
+    public isInstalled(): boolean {
         if (this._config.extensionId !== "") {
-            await vscode.extensions.getExtension(this._config.extensionId)?.activate();
+            this._extension = this._extension || vscode.extensions.getExtension(this._config.extensionId);
+            return !!this._extension;
+        }
+        return true;
+    }
+
+    public async activate(request: AgentRequest): Promise<void> {
+        if (this._config.extensionId !== "") {
+            this._extension = this._extension || vscode.extensions.getExtension(this._config.extensionId);
+            if (this._extension !== undefined) {
+                request.progress.report({ message: `Activating the ${this._config.displayName} extension...` })
+                await this._extension.activate();
+            }
         }
     }
 
@@ -121,7 +137,12 @@ export class WizardBasedExtension {
         } else if (typeof this._config.getWizardCommandsCommandId === "function") {
             return this._config.getWizardCommandsCommandId();
         } else {
-            return await vscode.commands.executeCommand<WizardBasedExtensionCommandConfig[]>(this._config.getWizardCommandsCommandId);
+            try {
+                return await vscode.commands.executeCommand<WizardBasedExtensionCommandConfig[]>(this._config.getWizardCommandsCommandId);
+            } catch (error) {
+                console.log(`Error getting wizard commands from ${this._config.displayName} extension: ${JSON.stringify(error)}`);
+                return [];
+            }
         }
     }
 

--- a/src/chat/wizardBasedExtensionSchema/wizardBasedExtensionSchema.ts
+++ b/src/chat/wizardBasedExtensionSchema/wizardBasedExtensionSchema.ts
@@ -7,7 +7,8 @@
 import { type IAzureUserInput } from "@microsoft/vscode-azext-utils";
 import * as vscode from "vscode";
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-import { AgentRequest } from "../agent";
+import { type AgentRequest } from "../agent";
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 import { type AzureUserInputQueue, type IAgentUserInput } from "./AgentUserInput";
 
 export type WizardBasedExtensionCommandConfig = {
@@ -104,7 +105,7 @@ export class WizardBasedExtension {
     public readonly runWizardCommandWithInputsCommandId: string;
 
     private readonly _config: WizardBasedExtensionConfig;
-    private _extension: vscode.Extension<any> | undefined;
+    private _extension: vscode.Extension<object> | undefined;
 
     constructor(config: WizardBasedExtensionConfig) {
         this.extensionId = config.extensionId;

--- a/src/chat/wizardBasedExtensionSchema/wizardExtensions.ts
+++ b/src/chat/wizardBasedExtensionSchema/wizardExtensions.ts
@@ -5,9 +5,9 @@
 
 import { WizardBasedExtension } from "./wizardBasedExtensionSchema";
 
-export function getNoCommandsWizardExtensionConfig(displayName: string): WizardBasedExtension {
+export function getNoCommandsWizardExtensionConfig(displayName: string, extensionId: string): WizardBasedExtension {
     return new WizardBasedExtension({
-        extensionId: "",
+        extensionId: extensionId,
         displayName: displayName,
         getWizardCommandsCommandId: "",
         runWizardCommandId: "",


### PR DESCRIPTION
- Progress agent output is now displayed while waiting for extension to activate.
- If brainstorm, learn, or might be interested are invoked, and an associated extension is not installed, then a button is displayed which offers to install it.