### PR TITLE
Improve the implementation of, and the reliability of invoking, the agent's default handler

### DIFF
--- a/src/chat/agentHelpSlashCommand.ts
+++ b/src/chat/agentHelpSlashCommand.ts
@@ -14,7 +14,7 @@ export function getAgentHelpCommand(agentSlashCommandsOwner: SlashCommandsOwner)
         {
             shortDescription: `Get help with using the @${agentName} agent.`,
             longDescription: `Get help with using the @${agentName} agent.`,
-            intentDescription: `This is best when users want to know what you can do for them, how you can help them, or how to best use you as an agent. You may be referred to as "you", "this", "bot" or other similar langauge. This is not the best if the user asks about or mentions a particular Azure service, topic, feature, or question.`,
+            intentDescription: `This is not a valid option if the user asks you do to something, or if the user mentions a particular Azure service, topic, or feature. Do not pick this option unless users are asking about how to interact with you. This is best when users want to know what you can do for them or need help understanding how to interact with you. You may be referred to as "you", "this", "bot", "agent", or other similar langauge.`,
             handler: (request) => agentHelpHandler(agentSlashCommandsOwner, request)
         }];
 }

--- a/src/chat/benchmarking/agentBenchmarks.ts
+++ b/src/chat/benchmarking/agentBenchmarks.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type AgentBenchmarkConfig } from "@microsoft/vscode-azext-utils";
+import { agentHelpCommandName } from "../agentHelpSlashCommand";
+import { defaultSlashCommandName } from "../slashCommands";
+
+export const helpBenchmarks: AgentBenchmarkConfig[] = [
+    {
+        name: "Agent Help Benchmark 1",
+        prompt: "How do I use you?",
+        acceptableHandlerChains: [[agentHelpCommandName]]
+    },
+    {
+        name: "Agent Help Benchmark 2",
+        prompt: "What can you do?",
+        acceptableHandlerChains: [[agentHelpCommandName]]
+    },
+    {
+        name: "Agent Help Benchmark 3",
+        prompt: "How does this bot help me?",
+        acceptableHandlerChains: [[agentHelpCommandName]]
+    },
+    {
+        name: "Agent Help Benchmark 4",
+        prompt: "Can this thing do anything useful?",
+        acceptableHandlerChains: [[agentHelpCommandName]]
+    },
+];
+
+export const defaultBenchmarks: AgentBenchmarkConfig[] = [
+    {
+        name: "Default Benchmark 1",
+        prompt: "Teach me about Microsoft Genomics",
+        acceptableHandlerChains: [[defaultSlashCommandName]]
+    },
+    {
+        name: "Default Benchmark 2",
+        prompt: "I need to lookup my last billing statement",
+        acceptableHandlerChains: [[defaultSlashCommandName]]
+    },
+    {
+        name: "Default Benchmark 3",
+        prompt: "How do I create an Power BI Embedded project?",
+        acceptableHandlerChains: [[defaultSlashCommandName]]
+    },
+    {
+        name: "Default Benchmark 4",
+        prompt: "What Azure services are currently in preview?",
+        acceptableHandlerChains: [[defaultSlashCommandName]]
+    },
+];

--- a/src/chat/benchmarking/benchmarking.ts
+++ b/src/chat/benchmarking/benchmarking.ts
@@ -50,6 +50,11 @@ export class AgentBenchmarker implements IAgentRequestHandler {
         this._extensionsToBenchmark.push(...extensions);
     }
 
+    public addBenchmarkConfigs(...benchmarkConfigs: AgentBenchmarkConfig[]): void {
+        this._benchmarks.push(...benchmarkConfigs);
+        this._benchmarksRunsStats.push(...benchmarkConfigs.map(() => []));
+    }
+
     public handleRequestOrPrompt(request: AgentRequest): Promise<SlashCommandHandlerResult> {
         return this._benchmarkerSlashCommandsOwner.handleRequestOrPrompt(request);
     }
@@ -66,8 +71,7 @@ export class AgentBenchmarker implements IAgentRequestHandler {
                     await extension.activate(request);
                     request.progress.report({ message: `Getting benchmark configs from the ${extension.extensionDisplayName} extension...` });
                     const benchmarkConfigs = await extension.getAgentBenchmarkConfigs();
-                    this._benchmarks.push(...benchmarkConfigs);
-                    this._benchmarksRunsStats.push(...benchmarkConfigs.map(() => []));
+                    this.addBenchmarkConfigs(...benchmarkConfigs);
                 } else {
                     request.progress.report({ message: `Skipping getting benchmark configs from the ${extension.extensionDisplayName} extension as it is not ${extension.isInstalled() ? "compatible" : "installed"}...` });
                 }
@@ -109,7 +113,7 @@ export class AgentBenchmarker implements IAgentRequestHandler {
     private async _runBenchmark(benchmarkIdx: number, request: AgentRequest): Promise<void> {
         const benchmark = this._benchmarks[benchmarkIdx];
 
-        this._debugBenchmarking(request.progress, `📋 Benchmark (${this._continuationIndex}/${this._benchmarks.length}): ${benchmark.name}\n💭 Prompt: '${benchmark.prompt}'...`);
+        this._debugBenchmarking(request.progress, `📋 Benchmark (${benchmarkIdx ?? this._continuationIndex}/${this._benchmarks.length}): ${benchmark.name}\n💭 Prompt: '${benchmark.prompt}'...`);
 
         const startTime = Date.now();
         const benchmarkRequest: AgentRequest = { ...request, userPrompt: benchmark.prompt, };

--- a/src/chat/copilotInteractions.ts
+++ b/src/chat/copilotInteractions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
-import  { type AgentRequest } from "./agent";
+import { type AgentRequest } from "./agent";
 
 export type CopilotInteractionResult = { copilotResponded: true, copilotResponse: string } | { copilotResponded: false, copilotResponse: undefined };
 

--- a/src/chat/slashCommands.ts
+++ b/src/chat/slashCommands.ts
@@ -81,6 +81,8 @@ export type SlashCommmandOwnerOptions = {
     disableIntentDetection?: boolean;
 };
 
+export const defaultSlashCommandName = "default";
+
 /**
  * A class that owns a set of slash commands and can handle requests for them.
  */
@@ -198,7 +200,7 @@ export class SlashCommandsOwner implements IAgentRequestHandler {
             // If after all of that, there is still no result, then use the default fallback handler (or no handler if there is no default fallback handler).
             if (!result) {
                 result = {
-                    refinedRequest: { ...request, slashCommand: "default", userPrompt: prompt, },
+                    refinedRequest: { ...request, slashCommand: defaultSlashCommandName, userPrompt: prompt, },
                     handler: typeof this._fallbackHandlers.default === "string" ?
                         this._invokeableSlashCommands.get(this._fallbackHandlers.default)?.handler :
                         this._fallbackHandlers.default


### PR DESCRIPTION
- Better empowerer intent detection to choose "no option".
- Improve intent description of agent's help command.
- Have the agent's default handler just re-use learn code.
- Add benchmarks around invoking agent's help command and agent's default handler.