### PR TITLE
More improvements to extension slash commands

### DIFF
--- a/src/chat/commonCommandsAndHandlers.ts
+++ b/src/chat/commonCommandsAndHandlers.ts
@@ -33,17 +33,7 @@ function learnHandler(config: LearnCommandConfig, request: AgentRequest): Promis
     return callWithTelemetryAndErrorHandling("learnHandler", async (actionContext) => {
         if (request.userPrompt.length === 0) {
             request.progress.report({ content: `If you want to learn more about ${config.topic}, simply ask me what it is you'd like to learn.\n` });
-            const followUps: vscode.ChatAgentFollowup[] = [];
-            if (config.associatedExtension !== undefined && !config.associatedExtension.isInstalled()) {
-                request.progress.report({ content: `\n\nAlso consider installing the ${config.associatedExtension.extensionDisplayName} extension for VS Code.` });
-                followUps.push({ commandId: "workbench.extensions.search", args: [config.associatedExtension.extensionId], title: `Install the ${config.associatedExtension.extensionDisplayName} Extension` });
-            }
-            const ragContent = await getMicrosoftLearnRagContent(actionContext, `Getting started or learning about ${config.topic}`);
-            followUps.push(...await generateSampleQuestionsFollowUps(config.topic, ragContent?.content, request));
-            if (config.noInputSuggestions !== undefined) {
-                followUps.push(...config.noInputSuggestions.map((suggestion) => ({ message: `@${agentName} ${suggestion}` })));
-            }
-            return { chatAgentResult: {}, followUp: followUps, };
+            return { chatAgentResult: {}, followUp: config.noInputSuggestions?.map((suggestion) => ({ message: `@${agentName} ${suggestion}` })), };
         } else {
             const ragContent = await getMicrosoftLearnRagContent(actionContext, request.userPrompt);
             const { copilotResponded, copilotResponse } = await verbatimCopilotInteraction(getLearnSystemPrompt(config, ragContent?.content), request);

--- a/src/chat/extensions/extensionSlashCommands.ts
+++ b/src/chat/extensions/extensionSlashCommands.ts
@@ -31,9 +31,9 @@ export class ExtensionSlashCommandsOwner {
         return [
             this._commandName,
             {
-                shortDescription: `Work with the ${this._extensionDisplayName} extension for VS Code and/or ${this._azureServiceName}`,
-                longDescription: `Use the command when you want to learn about or work with ${this._azureServiceName} or the ${this._extensionDisplayName} extension for VS Code.`,
-                intentDescription: `This is best when a user prompt could be related to the ${this._extensionDisplayName} extension for VS Code or ${this._azureServiceName}.`,
+                shortDescription: `Work with ${this._azureServiceName} and/or the ${this._extensionDisplayName} extension for VS Code.`,
+                longDescription: `Use the command when you want to learn about or work with ${this._azureServiceName} and/or the ${this._extensionDisplayName} extension for VS Code.`,
+                intentDescription: `This is best when a user prompt could be related to ${this._azureServiceName} and/or the ${this._extensionDisplayName} extension for VS Code.`,
                 handler: (...args) => this._handleExtensionSlashCommand(...args),
             }
         ]
@@ -53,7 +53,7 @@ export class ExtensionSlashCommandsOwner {
             await this._extension.activate(request);
 
             const extensionSlashCommands: SlashCommands = new Map([
-                getLearnCommand({ topic: `${this._extensionDisplayName} and/or the ${this._extensionDisplayName} extension for VS Code`, associatedExtension: this._extension }),
+                getLearnCommand({ topic: `${this._azureServiceName} and/or the ${this._extensionDisplayName} extension for VS Code`, associatedExtension: this._extension }),
             ]);
 
             if (this._extension.isInstalled()) {
@@ -68,7 +68,7 @@ export class ExtensionSlashCommandsOwner {
                 }
             }
 
-            const mightBeInterestedHandler = getMightBeInterestedHandler({ topic: `${this._extensionDisplayName} and/or the ${this._extensionDisplayName} extension for VS Code` });
+            const mightBeInterestedHandler = getMightBeInterestedHandler({ topic: `${this._azureServiceName} and/or the ${this._extensionDisplayName} extension for VS Code`, associatedExtension: this._extension });
             this._extensionSlashCommandsOwner = new SlashCommandsOwner({ noInput: mightBeInterestedHandler, default: mightBeInterestedHandler });
             this._extensionSlashCommandsOwner.addInvokeableSlashCommands(extensionSlashCommands);
         }

--- a/src/chat/slashCommands.ts
+++ b/src/chat/slashCommands.ts
@@ -108,7 +108,7 @@ export class SlashCommandsOwner implements IAgentRequestHandler {
      *
      * Will only handle the request if:
      * - There is a command and it is in the list of invokeable commands OR
-     * - Intent detection is not disabled.
+     * - Intent detection is not disabled and there is a prompt from which intent can be detected.
      */
     public async handleRequestOrPrompt(request: AgentRequest): Promise<SlashCommandHandlerResult> {
         const getHandlerResult = await this._getSlashCommandHandlerForRequest(request);
@@ -155,7 +155,7 @@ export class SlashCommandsOwner implements IAgentRequestHandler {
 
         // Only try to get a handler if:
         // - There is a command and it is in the list of invokeable commands OR
-        // - Intent detection is not disabled.
+        // - Intent detection is not disabled and there is a prompt from which intent can be detected.
         if ((command !== undefined && this._invokeableSlashCommands.has(command)) || !this._disableIntentDetection) {
             // If there is no prompt and no command, then use the noInput fallback handler (or no handler if there is no noInput fallback handler).
             if (!result && prompt === "" && !command) {
@@ -178,8 +178,8 @@ export class SlashCommandsOwner implements IAgentRequestHandler {
                 }
             }
 
-            // If intent detection is not disabled, then use intent detection to find a command (at this point there must be a prompt).
-            if (!result && this._disableIntentDetection !== true) {
+            // If intent detection is not disabled and there is a prompt from which intent can be detected, then use intent detection to find a command.
+            if (!result && prompt !== "" && this._disableIntentDetection !== true) {
                 const intentDetectionTargets = Array.from(this._invokeableSlashCommands.entries())
                     .map(([name, config]) => ({ name: name, intentDetectionDescription: config.intentDescription || config.shortDescription }));
                 const detectedTarget = await detectIntent(intentDetectionTargets, request);


### PR DESCRIPTION
- Have might be interested handler suggest installing extension if it isn't already installed.
- Swap order of extension name and Azure service in "topic" type strings.
- Fix slash command owner trying to do intent detection when there is no prompt.