### PR TITLE
Fix issue with summarizing/benchmarking

### DIFF
--- a/src/chat/benchmarking/agentBenchmarks.ts
+++ b/src/chat/benchmarking/agentBenchmarks.ts
@@ -19,6 +19,14 @@ export const multiPromptBenchmarks: AgentBenchmarkWithStepsConfig[] = [
                 prompt: "Actually, show me how with JavaScript please.",
                 acceptableHandlerChains: [["storage", "learn"]]
             },
+            {
+                prompt: "Can you add some more comments to that?",
+                acceptableHandlerChains: [["storage", "learn"]]
+            },
+            {
+                prompt: "Great! Can you also help me learn about any concept that the code requires knowing aobut?",
+                acceptableHandlerChains: [["storage", "learn"]]
+            }
         ]
     },
     {
@@ -31,6 +39,35 @@ export const multiPromptBenchmarks: AgentBenchmarkWithStepsConfig[] = [
             {
                 prompt: "Tell me more!",
                 acceptableHandlerChains: [["functions", "learn"]]
+            },
+            {
+                prompt: "Hmmm ok. I think I'd rather get to know more about Azure app service before going any further.",
+                acceptableHandlerChains: [["appservice", "learn"]]
+            },
+        ]
+    },
+    {
+        name: "Multi Prompt Benchmark 2",
+        steps: [
+            {
+                prompt: "What is the max size of a block blob?",
+                acceptableHandlerChains: [["storage", "learn"]]
+            },
+            {
+                prompt: "What if my blobs are video files?",
+                acceptableHandlerChains: [["storage", "learn"]]
+            },
+            {
+                prompt: "How about if I use azure files instead?",
+                acceptableHandlerChains: [["storage", "learn"]]
+            },
+            {
+                prompt: "For now let's assume I use blobs then. How can I save cost on storing my large video blobs?",
+                acceptableHandlerChains: [["storage", "learn"]]
+            },
+            {
+                prompt: "Will they still be easily accessible even if I do that?",
+                acceptableHandlerChains: [["storage", "learn"]]
             },
         ]
     },

--- a/src/chat/summarizing.ts
+++ b/src/chat/summarizing.ts
@@ -11,7 +11,7 @@ export async function summarizeHistoryThusFar(request: AgentRequest): Promise<st
         return request.userPrompt;
     } else {
         const systemPrompt = summarizeHistoryToSingleQuestionSystemPrompt1;
-        const maybeJsonCopilotResponse = await getResponseAsStringCopilotInteraction(systemPrompt, request, { includeHistory: "all", setCache: true, useCache: true });
+        const maybeJsonCopilotResponse = await getResponseAsStringCopilotInteraction(systemPrompt, request, { includeHistory: "requests", setCache: true, useCache: true });
         return maybeJsonCopilotResponse || request.userPrompt;
     }
 }


### PR DESCRIPTION
Turns out benchmarking was not including responses in history. Realizing this both reveals why summarizing worked awful outside of benchmarking, and how to make it work better outside of benchmarking: only ask agent to summarize with the user requests in history. 