### PR TITLE
enhance: Enhance Azure resource graph query UX

### DIFF
--- a/src/chat/argQuery/argQuerySlashCommand.ts
+++ b/src/chat/argQuery/argQuerySlashCommand.ts
@@ -84,7 +84,7 @@ function getTrimmedQueryResult(queryResponse: ResourceGraphModels.QueryResponse)
         const dataToPreserve: any = [];
         let numTokens = 0;
         // Estimate the number of tokens until it exceeds our limit
-        for (let entry of data) {
+        for (const entry of data) {
             const entryTokenCount = JSON.stringify(entry).length;
             // Make sure there is at least one entry in the data
             if (numTokens > 0 && numTokens + entryTokenCount > tokenLimit) {

--- a/src/chat/argQuery/argQuerySlashCommand.ts
+++ b/src/chat/argQuery/argQuerySlashCommand.ts
@@ -65,9 +65,12 @@ async function displayArgQuery(query: string, queryResponse: ResourceGraphModels
 }
 
 async function displayTrimWarning(request: AgentRequest) {
-    request.responseStream.markdown(`\n\n> ⚠️ The answer is based on trimmed result to prevent exceeding the language model's token limit.\n`);
+    request.responseStream.markdown(`\n\n> ⚠️ This answer is based on a trimmed result to prevent exceeding the language model's token limit.\n`);
 }
 
+/**
+ * @todo: Find a library to handle the LLM token size limit for all interactions.
+ */
 const tokenLimit = 4000;
 
 /**

--- a/src/chat/argQuery/argQuerySlashCommand.ts
+++ b/src/chat/argQuery/argQuerySlashCommand.ts
@@ -56,7 +56,7 @@ async function summarizeQueryResponse(queryResult: ArgQueryResult, request: Agen
 
 async function displayArgQuery(query: string, queryResponse: ResourceGraphModels.QueryResponse, request: AgentRequest): Promise<void> {
     request.responseStream.markdown(`\n\nThis information was retrieved by querying Azure Resource Graph with the following query:\n\n\`\`\`\n${query}\n\`\`\`\n`);
-    request.responseStream.markdown(`\n\nYou can use the button to view the result of the full query result.\n`);
+    request.responseStream.markdown(`\n\nYou can use the button to view the full query result.\n`);
     request.responseStream.button({
         title: "Show full query result",
         command: "azureAgent.showArgQueryResult",

--- a/src/chat/argQuery/argQuerySlashCommand.ts
+++ b/src/chat/argQuery/argQuerySlashCommand.ts
@@ -70,6 +70,7 @@ async function displayTrimWarning(request: AgentRequest) {
 
 /**
  * @todo: Find a library to handle the LLM token size limit for all interactions.
+ * https://github.com/microsoft/vscode-azure-agent/issues/101
  */
 const tokenLimit = 4000;
 

--- a/src/chat/argQuery/commands/showArgQueryResult.ts
+++ b/src/chat/argQuery/commands/showArgQueryResult.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceGraphModels } from "@azure/arm-resourcegraph";
+import { IActionContext, openReadOnlyContent } from "@microsoft/vscode-azext-utils";
+import { randomUUID } from "crypto";
+
+export async function showArgQueryResult(_actionContext: IActionContext, queryResponse: ResourceGraphModels.QueryResponse): Promise<void> {
+    await openReadOnlyContent({
+        label: "azure-resource-graph-query-result",
+        fullId: `arg-query-result-${randomUUID()}`
+    },
+        JSON.stringify(queryResponse, null, 2),
+        ".json"
+    );
+}

--- a/src/chat/argQuery/commands/showArgQueryResult.ts
+++ b/src/chat/argQuery/commands/showArgQueryResult.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ResourceGraphModels } from "@azure/arm-resourcegraph";
-import { IActionContext, openReadOnlyContent } from "@microsoft/vscode-azext-utils";
+import { type ResourceGraphModels } from "@azure/arm-resourcegraph";
+import { openReadOnlyContent, type IActionContext } from "@microsoft/vscode-azext-utils";
 import { randomUUID } from "crypto";
 
 export async function showArgQueryResult(_actionContext: IActionContext, queryResponse: ResourceGraphModels.QueryResponse): Promise<void> {

--- a/src/chat/argQuery/queryAzureResourceGraph.ts
+++ b/src/chat/argQuery/queryAzureResourceGraph.ts
@@ -55,7 +55,10 @@ async function queryArg(subscription: AzureSubscription, query: string, request:
         request.responseStream.progress("Querying Azure Resource graph...");
 
         const resourceGraphClient = new ResourceGraphClient(tokenCredential);
-        const response = await resourceGraphClient.resources({ query: query });
+        const response = await resourceGraphClient.resources({
+            query: query,
+            options: { resultFormat: "objectArray" }
+        });
         return response;
     }
     return undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,10 @@
 'use strict';
 
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
-import { callWithTelemetryAndErrorHandling, createAzExtOutputChannel, registerUIExtensionVariables, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { callWithTelemetryAndErrorHandling, createAzExtOutputChannel, registerCommand, registerUIExtensionVariables, type IActionContext } from '@microsoft/vscode-azext-utils';
 import type * as vscode from 'vscode';
 import { registerChatParticipant } from './chat/agent';
+import { showArgQueryResult } from './chat/argQuery/commands/showArgQueryResult';
 import { ext } from './extensionVariables';
 
 export async function activateInternal(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<void> {
@@ -18,6 +19,8 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
 
     registerUIExtensionVariables(ext);
     registerAzureUtilsExtensionVariables(ext);
+
+    registerCommand("azureAgent.showArgQueryResult", showArgQueryResult);
 
     await callWithTelemetryAndErrorHandling(`${ext.prefix}.activate`, async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';


### PR DESCRIPTION
related to: https://github.com/microsoft/vscode-azure-agent/issues/96

The query response may be very large (e.g. the response of 10 storage accounts can result in a JSON string of >30k characters). My observation is that when that happens, the language model starts ignoring the query response we got from Azure Resource Graph, which actually gives what the user want, and emitting generic answers such as "I am sorry I can't help" or "I don't know the answer but you can query it yourself by using Azure CLI or using Azure Resource Graph", etc.

This PR postprocesses the query result so the language model can really summarize the information from the "trimmed" version of the result. It also adds the feature to allow the user to view the full query result in case that's what the user is interested in.

<img width="586" alt="Screenshot 2024-03-14 at 4 11 04 PM" src="https://github.com/microsoft/vscode-azure-agent/assets/39359541/2b3fce1f-f2b4-4fe2-a14a-0f535f0d7227">
