### PR TITLE
Refine learn command behavior

### DIFF
--- a/src/chat/argQuery/argQuerySlashCommand.ts
+++ b/src/chat/argQuery/argQuerySlashCommand.ts
@@ -77,7 +77,7 @@ function getTrimmedQueryResult(queryResponse: ResourceGraphModels.QueryResponse,
     let data: any = queryResponse.data;
     if (Array.isArray(data)) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const dataToPreserve: any = [];
+        const dataToPreserve: any[] = [];
         let numTokens = 0;
         // Estimate the number of tokens until it exceeds our limit
         for (const entry of data) {

--- a/src/chat/argQuery/argQuerySlashCommand.ts
+++ b/src/chat/argQuery/argQuerySlashCommand.ts
@@ -49,7 +49,7 @@ async function argQueryHandler(request: AgentRequest): Promise<SlashCommandHandl
 }
 
 async function summarizeQueryResponse(queryResult: ArgQueryResult, request: AgentRequest): Promise<void> {
-    let systemPrompt = `You are an expert in Azure resources. The user has asked a question for the user's Azure resources. Answer the question using the query result of Azure Resource Graph: ${JSON.stringify(queryResult, null, 3)}.`;
+    let systemPrompt = `You are an expert in Azure resources. The user has asked a question about their Azure resources. Answer the question using the query result of Azure Resource Graph: ${JSON.stringify(queryResult, null, 3)}.`;
     if (queryResult.count < queryResult.totalRecords) {
         systemPrompt += "\nAlso mention that the answer is generated based on a subset of the user's Azure resources.";
     }
@@ -60,7 +60,7 @@ async function displayArgQuery(query: string, queryResponse: ResourceGraphModels
     request.responseStream.markdown(`\n\nThis information was retrieved by querying Azure Resource Graph with the following query:\n\n\`\`\`\n${query}\n\`\`\`\n`);
     request.responseStream.markdown(`\n\nYou can use the button to view the full query result.\n`);
     request.responseStream.button({
-        title: "Show full query result",
+        title: "Show Full Query Result",
         command: "azureAgent.showArgQueryResult",
         arguments: [{ queryResponse }]
     });

--- a/src/chat/argQuery/queryAzureResourceGraph.ts
+++ b/src/chat/argQuery/queryAzureResourceGraph.ts
@@ -49,8 +49,6 @@ export async function queryAzureResourceGraph(actionContext: IActionContext, pro
     return undefined;
 }
 
-const facetSize = 5;
-
 async function queryArg(subscription: AzureSubscription, query: string, request: AgentRequest): Promise<ResourceGraphModels.ResourcesResponse | undefined> {
     const tokenCredential = subscription.credential;
     if (tokenCredential !== undefined) {

--- a/src/chat/argQuery/queryAzureResourceGraph.ts
+++ b/src/chat/argQuery/queryAzureResourceGraph.ts
@@ -59,14 +59,7 @@ async function queryArg(subscription: AzureSubscription, query: string, request:
         const resourceGraphClient = new ResourceGraphClient(tokenCredential);
         const response = await resourceGraphClient.resources({
             query: query,
-            options: { resultFormat: "objectArray" },
-            facets: [{
-                expression: "id,name,type,location,resourceGroup,subscriptionId",
-                options: {
-                    sortOrder: "asc",
-                    top: facetSize
-                }
-            }]
+            options: { resultFormat: "objectArray" }
         });
         return response;
     }

--- a/src/chat/learn/learnSlashCommand.ts
+++ b/src/chat/learn/learnSlashCommand.ts
@@ -44,9 +44,9 @@ function learnHandler(config: LearnCommandConfig, request: AgentRequest): Promis
             request.responseStream.markdown(`If you want to learn more about ${config.topic}, simply ask me what it is you'd like to learn.\n`);
             return { chatAgentResult: {}, followUp: config.noInputSuggestions?.map((suggestion) => ({ prompt: `${suggestion}` })), };
         } else {
+            // @todo: Find better way to summarize the full conversation history
             const questionForRagContent = await summarizeHistoryThusFar(request);
             const ragContent = await getMicrosoftLearnRagContent(actionContext, questionForRagContent, request);
-
 
             const resourceInfo = await summarizeAzureResourceInfo(request);
             ext.outputChannel.debug("summarizedResourceInfo", resourceInfo);
@@ -73,7 +73,7 @@ function learnHandler(config: LearnCommandConfig, request: AgentRequest): Promis
             if (argQueryResult && summarizedQueryResult) {
                 request.responseStream.markdown(`This content is generated based on the result of an Azure Resource Graph query.`);
                 request.responseStream.button({
-                    title: "Show full query result",
+                    title: "Show Full Query Result",
                     command: "azureAgent.showArgQueryResult",
                     arguments: [{ queryResponse: argQueryResult.response }]
                 });


### PR DESCRIPTION
- Re-design how the learn command incorporate information from ARG query
- Stop using facet post-processing since it's not flexible enough
- Use language model to summarize query results
- Limit the number of records we summarize from the query results
- Fine tune prompts